### PR TITLE
Handle case were zero large SVs are called

### DIFF
--- a/scripts/filter_calls.py
+++ b/scripts/filter_calls.py
@@ -137,7 +137,7 @@ def filter_calls(args, dbo_args, endpoint_args):
     out_fp.write(header)
     sv_id = 0
     n_svcall = len(final_retained_sv_list)
-    n_digit = int(math.log10(n_svcall) + 2)
+    n_digit = int(math.log10(n_svcall) + 2) if n_svcall > 0 else 0
 
     for svcall in final_retained_sv_list:
         if svcall.ft == '.':


### PR DESCRIPTION
Thank you for creating this wonderful tool!

I have been running LinkedSV a while and started running into this error (see excerpt in log below). 

```
[12/07/2020 14:50:41 (243.913 MB)] number of retained SVs: 0
Traceback (most recent call last):
  File "/Users/pontus.hojer/miniconda3/envs/blr-latest/bin/linkedsv.py", line 313, in <module>
    main()
  File "/Users/pontus.hojer/miniconda3/envs/blr-latest/bin/linkedsv.py", line 59, in main
    filter_calls.filter_calls(args, dbo_args, endpoint_args)
  File "/Users/pontus.hojer/projects/LinkedSV/scripts/filter_calls.py", line 137, in filter_calls
    n_digit = int(math.log10(n_svcall) + 2)
ValueError: math domain error
```

The error happens when I run on a single chromosome the number of large SV is sometimes 0. This causes this fatal error. However there are ofter `small_deletions` and/or `large_cnv` called for the same chromsome. With this edit the tool will continue to call `small_deletions` and `large_cnv`.
